### PR TITLE
don't use fp16 in giou loss

### DIFF
--- a/fvcore/nn/giou_loss.py
+++ b/fvcore/nn/giou_loss.py
@@ -25,7 +25,8 @@ def giou_loss(
                  'sum': The output will be summed.
         eps (float): small number to prevent division by zero
     """
-
+    boxes1 = boxes1.float()
+    boxes2 = boxes2.float()
     x1, y1, x2, y2 = boxes1.unbind(dim=-1)
     x1g, y1g, x2g, y2g = boxes2.unbind(dim=-1)
 


### PR DESCRIPTION
There is no speed benefit using fp16 in losses anyway. There might be numerical problems instead since it's doing sigmoid / cross entropy. So should be good to change regardless of the bug.